### PR TITLE
Fix truncated script for image generation

### DIFF
--- a/09-building-image-applications/python/oai-app.py
+++ b/09-building-image-applications/python/oai-app.py
@@ -44,12 +44,19 @@ try:
 # catch exceptions
 except client.error.InvalidRequestError as err:
     print(err)
-
 # ---creating variation below---
 
-
 response = client.images.create_variation(
-  image=open(image_path, "rb"),
-  n=1,
-  size="1024x1024"
+    image=open(image_path, "rb"),
+    n=1,
+    size="1024x1024"
 )
+
+variation_url = response.data[0].url
+variation_path = os.path.join(image_dir, 'variation-image.png')
+variation_image = requests.get(variation_url).content
+with open(variation_path, "wb") as image_file:
+    image_file.write(variation_image)
+
+image = Image.open(variation_path)
+image.show()


### PR DESCRIPTION
## Summary
- repair end of `oai-app.py` in the image generation lesson
- handle generated variation and display the image

## Testing
- `python3 -m py_compile 09-building-image-applications/python/oai-app.py`

------
https://chatgpt.com/codex/tasks/task_e_6861568e77088331be833aa229d3ae42